### PR TITLE
Fix thumbnail display error in archives page

### DIFF
--- a/archives.ftl
+++ b/archives.ftl
@@ -13,7 +13,7 @@
                         <#if post.thumbnail?? && post.thumbnail!=''>
                             <a href="${post.thumbnail}" class="media-left">
                                 <p class="image is-64x64">
-                                    <img class="thumbnail" src="${post.fullPath!}" alt="${post.title!}">
+                                    <img class="thumbnail" src="${post.thumbnail!}" alt="${post.title!}">
                                 </p>
                             </a>
                         </#if>


### PR DESCRIPTION
Archives页面文章缩略图显示异常，原因是路径错误。